### PR TITLE
Kotlin class alternative path

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,7 +64,7 @@ tasks.register<JacocoReport>("jacocoTestReport") {
 
     val kotlinClasses = fileTree(
         mapOf(
-            "dir" to "${buildDir}/tmp/kotlin-classes/debug",
+            "dir" to "${buildDir}/intermediates/classes/debug/transformDebugClassesWithAsm/dirs",
             "excludes" to excludes
         )
     )


### PR DESCRIPTION
Updating kotlinClasses to use a new path suggested by https://issuetracker.google.com/issues/161300933#comment21

This is much simpler and way more in line with what I am hoping to achieve.

However, I don't know enough about this solution to be 100% certain this is correct - will it change in the future with another update? I've asked in the issue tracker ticket, maybe we have some confidence about this based on the feedback...